### PR TITLE
Update external-docker-registry-integration.adoc

### DIFF
--- a/playbooks/continuous_delivery/external-docker-registry-integration.adoc
+++ b/playbooks/continuous_delivery/external-docker-registry-integration.adoc
@@ -74,6 +74,8 @@ oc secrets new-dockercfg external-registry \
     --docker-server=external-registry.example.com:5000
 ----
 
+NOTE: When logging into a remote OpenShift cluster, You must use your oc login token instead of your user's password.
+
 Alternatively, if the docker client was used to login to a remote registry and generate a configuration file containing the authentication details, this file can be stored as a secret within OpenShift. Two docker authentication formats are available: `config.json` and the legacy `.dockercfg`. Both are compatible for storage within OpenShift.
 
 To store a file in the `config.json` format as a secret within OpenShift, execute the following command


### PR DESCRIPTION
#### What is this PR About?
This PR adds a gentle reminder to the documentation that reminds consultants and clients alike that the token is used to login to the docker registry.

During times of high-stress or trying to find a solution and running into multiple problems. It can be easy to forget that you must use your token to login. This assists with that.

#### How should we test or review this PR?
Normal testing process for site content and yaml syntax should be observed.

#### Is there a relevant Trello card or Github issue open for this?
No.

#### Who would you like to review this?
cc: @redhat-cop/cant-contain-this
